### PR TITLE
Added copy to Vector2f

### DIFF
--- a/sf.pyx
+++ b/sf.pyx
@@ -416,6 +416,9 @@ cdef class Vector2f:
             return self
         return NotImplemented
 
+    def copy(self):
+        return Vector2f(self.p_this.x, self.p_this.y)
+
     property x:
         def __get__(self):
             return self.p_this.x


### PR DESCRIPTION
The assignment operator v1 = v2 doesn't create a copy of a Vector2f, so changes
to v1 would be copied in v2.  I added the function v2.copy() to make a true
copy.
