### PR TITLE
fixed shader example

### DIFF
--- a/examples/blur.sfx
+++ b/examples/blur.sfx
@@ -1,10 +1,11 @@
 uniform sampler2D texture;
-uniform float offset;
+uniform float offsetx;
+uniform float offsety;
 
 void main()
 {
-    vec2 offx = vec2(offset, 0.0);
-    vec2 offy = vec2(0.0, offset);
+    vec2 offx = vec2(offsetx, 0.0);
+    vec2 offy = vec2(0.0, offsety);
 
     vec4 pixel = texture2D(texture, gl_TexCoord[0].xy)               * 1.0 +
                  texture2D(texture, gl_TexCoord[0].xy - offx)        * 2.0 +

--- a/examples/shader.py
+++ b/examples/shader.py
@@ -15,7 +15,8 @@ def main():
 
     shader = sf.Shader.load_from_file('blur.sfx')
     shader.set_current_texture('texture')
-    shader.set_parameter('offset', 1./image.width)
+    shader.set_parameter('offsetx', 1./image.width)
+    shader.set_parameter('offsety', 1./image.height)
 
     shader2 = sf.Shader.load_from_file('edge.sfx')
     shader2.set_current_texture('texture')


### PR DESCRIPTION
the shader example was broken. now it should work.

```
Traceback (most recent call last):
  File "shader.py", line 37, in <module>
    main()
  File "shader.py", line 12, in main
    sprite = sf.Sprite(image)
  File "sf.pyx", line 1773, in sf.Sprite.__cinit__ (sf.cpp:19706)
TypeError: Argument 'texture' has incorrect type (expected sf.Texture, got sf.Image)
```
