### PR TITLE
Fixed sf.Image.load_from_memory (length arg passed to the native method was wrong)

### DIFF
--- a/sf.pyx
+++ b/sf.pyx
@@ -48,9 +48,6 @@ cimport declkey
 cimport declmouse
 cimport declstyle
 
-cdef extern from "Python.h":
-    char *PyString_AsString(object)
-
 cdef error_messages = {}
 cdef error_messages_lock = threading.Lock()
 


### PR DESCRIPTION
sf.Image.load_from_memory called its native function with a wrong argument.

As long as images data don't end with a null character like string, using len(char*) to find out its length won't work (because it implicitly uses strlen which searches until it finds '\0' to find out its length).

It's impossible to know its length unless we ask for it. Instead of using a method with two parameters (and see ugly code like sf.Image.load_from_memory(img_data, len(img_data))), it's better to get the python object itself and therefore use len(py_string).

Once we have the python string object, we can't pass it directly through its native method because cython converts implicitly to char\* and make the compilation failed because a void\* is required. Then we don't have any control any more to cast it into void*.

A hacky solution would be to cheat the compiler by modifying the declaration of it and pretending sf::Image::LoadFromMemory requires a char\* but it wouldn't be clean.

We have to explicitly convert the python string to a char\* then cast it to void\* before sending it which can be done with PyString_AsString.
