### PR TITLE
Fixed examples.

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -7,6 +7,8 @@ import sf
 def main():
     window = sf.RenderWindow(sf.VideoMode(640, 480), 'Events example')
     window.framerate_limit = 60
+    window.clear(sf.Color.WHITE)
+    window.display()
     running = True
 
     while running:
@@ -17,8 +19,8 @@ def main():
             # Stop running if the application is closed
             # or if the user presses Escape
             if (event.type == sf.Event.CLOSED or
-                (event.type == sf.Event.KEY_PRESSED and
-                 event.code == sf.Keyboard.ESCAPE)):
+               (event.type == sf.Event.KEY_PRESSED and
+                event.code == sf.Keyboard.ESCAPE)):
                 running = False
 
     window.close()

--- a/examples/pixels.py
+++ b/examples/pixels.py
@@ -25,6 +25,8 @@ def main():
 
             if s:
                 color = sf.Color(*unpacker.unpack(s))
+                mean = (color.r + color.g + color.b) / 3
+                color.r = color.g = color.b = mean
                 new_image[i,j] = color
             else:
                 pass

--- a/examples/renderimage.py
+++ b/examples/renderimage.py
@@ -1,17 +1,27 @@
 #! /usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-import sf
-import sys
+# Please note that this example may not work on all GPUs (eg. intel chipsets)
+# because of a bug in the drivers. See the corresponding SFML issue:
+# https://github.com/LaurentGomila/SFML/issues/101
 
+import sf
 
 def main():
     window = sf.RenderWindow(sf.VideoMode(640, 480), 'RenderImage example')
     window.framerate_limit = 60
     running = True
     
-    rect0 = sf.Shape.rectangle(5, 5, 90, 50, sf.Color.GREEN, 2, sf.Color.BLUE)
-    rect1 = sf.Shape.rectangle(20.0, 30.0, 50.0, 50.0, sf.Color.CYAN)
+    rect0 = sf.RectangleShape((5, 5))
+    rect0.position = (90, 50)
+    rect0.fill_color = sf.Color.GREEN
+    rect0.outline_color = sf.Color.BLUE
+    rect0.outline_thickness = 2.0
+
+    rect1 = sf.RectangleShape((20, 30))
+    rect1.position = (50, 50)
+    rect1.fill_color = sf.Color.CYAN
+
     ri = sf.RenderTexture(110, 110)
     ri.clear(sf.Color(0, 0, 0, 0))
     ri.draw(rect0)

--- a/examples/text.py
+++ b/examples/text.py
@@ -10,8 +10,8 @@ def main():
     text = sf.Text(u'éèà', sf.Font.DEFAULT_FONT, 100)
     text.color = sf.Color.BLACK
     text.style = sf.Text.UNDERLINED | sf.Text.BOLD | sf.Text.ITALIC
-    text.x = window.width / 2.0 - text.rect.width / 2.0
-    text.y = window.height / 2.0 - text.rect.height / 2.0
+    text.x = window.width / 2.0 - text.global_bounds.width / 2.0
+    text.y = window.height / 2.0 - text.global_bounds.height / 2.0
     running = True
 
     while running:

--- a/src/sf.pyx
+++ b/src/sf.pyx
@@ -85,7 +85,7 @@ cdef error_messages_lock = threading.Lock()
 # http://docs.python.org/extending/extending.html#providing-a-c-api-for-an-extension-module.
 # The problem is that this function needs to be called in hacks.cpp,
 # and Cython doesn't (AFAIK) make any difference between ``available
-# acros translations units'' and ``available at runtime in the shared
+# across translations units'' and ``available at runtime in the shared
 # object/DLL''.
 cdef public void set_error_message(char* message):
     ident = threading.current_thread().ident


### PR DESCRIPTION
Cleaner examples/events.py window.
Fixed examples/text.py using an undefined property.
Pixel manipulation example with actual pixel manipulation.
Fixed examples/renderimage.py : the example was using sf.Shape.rectangle
which looks like a deprecated (but smaller) way to instanciate a
sf.RectangleShape.

Also fixed a typo in src/sf.pyx.

lowleveldrawable.py is not working but I don't know how to fix this.
I did not test renderimage.py because my GPU/drivers can't handle FBOs (see the comments).
