### PR TITLE
Get Vector2f division operators working with Python3

### DIFF
--- a/src/sf.pyx
+++ b/src/sf.pyx
@@ -530,18 +530,30 @@ cdef class Vector2f:
             return self
         return NotImplemented
 
-    def __div__(a, b):
+    def _division(a, b):
         if isinstance(a, Vector2f) and isinstance(b, (int, float)):
             return Vector2f(a.x / <float>b, a.y / <float>b)
 
         return NotImplemented
 
-    def __idiv__(self, b):
+    def __div__(a, b):
+        return a._division(b)
+
+    def __truediv__(a, b):
+        return a._division(b)
+
+    def _idivision(self, b):
         if isinstance(b, (int, float)):
             self.p_this.x /= <float>b
             self.p_this.y /= <float>b
             return self
         return NotImplemented
+
+    def __idiv__(self, b):
+        return self.__idivision(b)
+
+    def __itruediv__(self, b):
+        return self.__idivision(b)
 
     def copy(self):
         return Vector2f(self.p_this.x, self.p_this.y)


### PR DESCRIPTION
Python3 does not use `__div__` but `__floordiv__` and `__truediv__` so expressions like `sf.Vector2f(4, 2) / 7` raised `TypeError` exceptions.
I did not implement `__floordiv__` because it does not make much sense with a vector of floats.

`Time.__div__` should get the same treatment but I could not get it to work :

```
src/sf.cpp:9674:15: error: cannot convert ‘PyObject* {aka _object*}’ to ‘__pyx_obj_2sf_Time*’ in assignment
```

Did not make much sense to me.
